### PR TITLE
Add SQLite logging for transaction classifications

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,9 +1,13 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 from pydantic import BaseModel
 import logging
 from pathlib import Path
 import joblib
 import pandas as pd
+from sqlalchemy.orm import Session
+
+from db import models
+from db.database import SessionLocal, init_db
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -13,16 +17,43 @@ model = joblib.load(MODEL_PATH)
 
 app = FastAPI()
 
+
 class Transaction(BaseModel):
     valor: float
     localizacao: str
     ip: str
     cartao: str
 
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.on_event("startup")
+def on_startup():
+    init_db()
+
+
 @app.post("/classify")
-def classify(transaction: Transaction):
+def classify(transaction: Transaction, db: Session = Depends(get_db)):
     df = pd.DataFrame([transaction.dict()])
     proba = model.predict_proba(df)[:, 1][0]
     is_fraud = proba >= 0.5
     logger.info("Transaction classified with probability %.4f", proba)
+
+    db_transacao = models.Transacao(
+        valor=transaction.valor,
+        localizacao=transaction.localizacao,
+        ip=transaction.ip,
+        cartao=transaction.cartao,
+        probabilidade_fraude=proba,
+        is_fraud=is_fraud,
+    )
+    db.add(db_transacao)
+    db.commit()
+
     return {"fraud_probability": proba, "is_fraud": is_fraud}

--- a/db/database.py
+++ b/db/database.py
@@ -1,0 +1,18 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///./fraudes.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def init_db() -> None:
+    """Create database tables."""
+    import db.models  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)

--- a/db/models.py
+++ b/db/models.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, Float, String, Boolean, DateTime
+from sqlalchemy.sql import func
+
+from db.database import Base
+
+
+class Transacao(Base):
+    __tablename__ = "transacoes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    valor = Column(Float, nullable=False)
+    localizacao = Column(String, nullable=False)
+    ip = Column(String, nullable=False)
+    cartao = Column(String, nullable=False)
+    probabilidade_fraude = Column(Float, nullable=False)
+    is_fraud = Column(Boolean, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/db/setup_db.py
+++ b/db/setup_db.py
@@ -1,0 +1,7 @@
+"""Initialize the SQLite database."""
+from db.database import init_db
+
+
+if __name__ == "__main__":
+    init_db()
+    print("Database initialized.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ fastapi
 uvicorn
 pydantic
 scikit-learn
-scikit-learn
 joblib
+sqlalchemy


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and SQLite setup utilities
- log classifications into `transacoes` table
- include database dependencies

## Testing
- `python -m db.setup_db` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acdfc532b88323b0a5c33588f8cb11