### PR TITLE
Add pytest tests for simulator and API classify endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ Para utilizar uma API ou outro banco, defina a variável `DATA_SOURCE` com a URL
 
 ## 🧪 Testes
 
+O projeto utiliza `pytest` para rodar os testes unitários e de integração.
+
 ```bash
-# Em breve: testes de API e validação
-pytest tests/
+pytest
 ```
 
 ---

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ streamlit
 plotly
 scikit-learn
 joblib
+pytest

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import numpy as np
+import joblib
+from fastapi.testclient import TestClient
+
+
+class DummyModel:
+    def predict_proba(self, X):
+        return np.array([[0.1, 0.9]] * len(X))
+
+
+model_path = Path("model/model.pkl")
+model_path.parent.mkdir(exist_ok=True)
+joblib.dump(DummyModel(), model_path)
+
+from api.main import app
+
+
+def test_classify_endpoint():
+    with TestClient(app) as client:
+        payload = {
+            "valor": 123.45,
+            "localizacao": "Sao Paulo",
+            "ip": "192.168.0.1",
+            "cartao": "1234567890123456",
+        }
+        response = client.post("/classify", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert set(data.keys()) == {"fraud_probability", "is_fraud"}
+        assert isinstance(data["fraud_probability"], float)
+        assert isinstance(data["is_fraud"], bool)
+
+
+def teardown_module(module):
+    model_path.unlink(missing_ok=True)
+    db_path = Path("fraudes.db")
+    if db_path.exists():
+        db_path.unlink()

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,14 @@
+import pandas as pd
+from simulator.generate import gerar_dados
+
+
+def test_generate_default_volume():
+    df = gerar_dados()
+    assert len(df) == 1000
+    assert df["fraude"].sum() == 100
+
+
+def test_generate_fields_presence():
+    df = gerar_dados(1, 1)
+    expected_columns = {"id_transacao", "nome", "email", "cartao", "data", "valor", "localizacao", "ip", "fraude"}
+    assert set(df.columns) == expected_columns


### PR DESCRIPTION
## Summary
- add unit tests for simulator data generation
- add integration test for `/classify` endpoint using FastAPI's TestClient
- configure pytest and document test execution

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68ace557d9888323ba58ff2d4525eef7