### PR TITLE
Add Dockerfiles for api, simulator, and dashboard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.so
+.env
+.venv
+venv/
+.env/
+.git
+.gitignore
+.pytest_cache/
+*.log
+*.sqlite
+*.db
+data/raw/

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+WORKDIR /app
+
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+WORKDIR /app
+
+CMD ["streamlit", "run", "dashboard/app.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/docker/simulator/Dockerfile
+++ b/docker/simulator/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+WORKDIR /app
+
+CMD ["python", "simulator/generate.py"]


### PR DESCRIPTION
## Summary
- add Dockerfiles for API, simulator, and dashboard services
- add shared .dockerignore for cleaner Docker builds

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68ad091a628c8323ab995305cc08992b