### PR TITLE
Add docker-compose configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ Para utilizar uma API ou outro banco, defina a variável `DATA_SOURCE` com a URL
 
 ---
 
+## 🐳 Docker Compose
+
+Todos os serviços (API, simulador, dashboard e banco de dados opcional) podem ser iniciados com o Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+Os diretórios `./data` e `./model` são montados como volumes para compartilhar dados e modelos entre os containers.
+
+---
+
 ## 🧪 Testes
 
 O projeto utiliza `pytest` para rodar os testes unitários e de integração.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+version: '3.8'
+
+services:
+  api:
+    build: ./docker/api
+    ports:
+      - "8000:8000"
+    volumes:
+      - data:/app/data
+      - model:/app/model
+    depends_on:
+      - simulator
+      - db
+    networks:
+      - internal
+
+  simulator:
+    build: ./docker/simulator
+    volumes:
+      - data:/app/data
+    networks:
+      - internal
+
+  dashboard:
+    build: ./docker/dashboard
+    ports:
+      - "8501:8501"
+    depends_on:
+      - simulator
+    volumes:
+      - data:/app/data
+      - model:/app/model
+    networks:
+      - internal
+
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: fraude
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - internal
+
+volumes:
+  data:
+    driver: local
+    driver_opts:
+      type: none
+      device: ./data
+      o: bind
+  model:
+    driver: local
+    driver_opts:
+      type: none
+      device: ./model
+      o: bind
+  postgres_data:
+
+networks:
+  internal:
+    driver: bridge


### PR DESCRIPTION
## Summary
- add docker-compose for API, simulator, dashboard, and optional PostgreSQL
- document docker-compose usage

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68ad0a7570708323a90b825698e4ef61