### PR TITLE
Add GitLab CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,44 @@
+image: docker:latest
+
+services:
+  - docker:dind
+
+variables:
+  DOCKER_HOST: tcp://docker:2375/
+  DOCKER_DRIVER: overlay2
+  DOCKER_TLS_CERTDIR: ""
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+
+stages:
+  - build
+  - test
+  - deploy
+
+cache:
+  key: ${CI_PROJECT_NAME}
+  paths:
+    - .cache/pip
+
+before_script:
+  - apk add --no-cache docker-compose
+
+build:
+  stage: build
+  script:
+    - docker-compose -f docker-compose.yml build
+  rules:
+    - if: $CI_COMMIT_BRANCH
+
+test:
+  stage: test
+  script:
+    - docker-compose run --rm api pytest
+  rules:
+    - if: $CI_COMMIT_BRANCH
+
+deploy:
+  stage: deploy
+  script:
+    - docker-compose -f docker-compose.yml push
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'


### PR DESCRIPTION
## Summary
- add GitLab CI pipeline with build, test and deploy stages using docker

## Testing
- `pytest` *(fails: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68ad0b87f45c83238b4546da50c9bd74