### PR TITLE
docs: add docker usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,15 +116,25 @@ Para utilizar uma API ou outro banco, defina a variável `DATA_SOURCE` com a URL
 
 ---
 
-## 🐳 Docker Compose
-
-Todos os serviços (API, simulador, dashboard e banco de dados opcional) podem ser iniciados com o Docker Compose:
+## 🐳 Docker
 
 ```bash
-docker-compose up --build
+# Build das imagens
+docker-compose build
+
+# Subir todos os serviços
+docker-compose up
+
+# Executar simulador isolado
+docker-compose run --rm simulator
 ```
 
+- API disponível em [http://localhost:8000](http://localhost:8000) (`/docs` para Swagger).
+- Dashboard acessível em [http://localhost:8501](http://localhost:8501).
+
 Os diretórios `./data` e `./model` são montados como volumes para compartilhar dados e modelos entre os containers.
+
+A pipeline CI/CD do projeto utiliza [GitLab CI/CD](https://docs.gitlab.com/ee/ci/) e está definida em [`./.gitlab-ci.yml`](.gitlab-ci.yml).
 
 ---
 


### PR DESCRIPTION
## Summary
- document docker compose workflow with build, run, and simulator commands
- explain exposed ports for API (8000) and dashboard (8501)
- reference GitLab CI/CD pipeline configuration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0c23bda4832395416e1c87ee05f8