### PR TITLE
Add categorical feature encoding and pipeline usage

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -12,8 +12,8 @@ from db.database import SessionLocal, init_db
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-MODEL_PATH = Path(__file__).resolve().parents[1] / "model" / "model.pkl"
-model = joblib.load(MODEL_PATH)
+PIPELINE_PATH = Path(__file__).resolve().parents[1] / "model" / "model.pkl"
+pipeline = joblib.load(PIPELINE_PATH)
 
 app = FastAPI()
 
@@ -41,7 +41,7 @@ def on_startup():
 @app.post("/classify")
 def classify(transaction: Transaction, db: Session = Depends(get_db)):
     df = pd.DataFrame([transaction.dict()])
-    proba = model.predict_proba(df)[:, 1][0]
+    proba = pipeline.predict_proba(df)[:, 1][0]
     is_fraud = proba >= 0.5
     logger.info("Transaction classified with probability %.4f", proba)
 

--- a/model/train.py
+++ b/model/train.py
@@ -4,6 +4,9 @@ import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import OneHotEncoder
+from sklearn.pipeline import Pipeline
 import joblib
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -25,11 +28,29 @@ def load_data(path: str) -> pd.DataFrame:
 def prepare_data(df: pd.DataFrame):
     df["valor"] = df["valor"].astype(float)
     df["fraude"] = df["fraude"].astype(int)
-    X = df[["valor"]]
+    X = df[["valor", "localizacao", "ip", "cartao"]]
     y = df["fraude"]
-    return train_test_split(X, y, test_size=0.2, random_state=42)
 
-def train_and_evaluate(X_train, X_test, y_train, y_test):
+    categorical_features = ["localizacao", "ip", "cartao"]
+    numeric_features = ["valor"]
+
+    preprocessor = ColumnTransformer(
+        transformers=[
+            ("cat", OneHotEncoder(handle_unknown="ignore"), categorical_features),
+            ("num", "passthrough", numeric_features),
+        ]
+    )
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+
+    X_train = preprocessor.fit_transform(X_train)
+    X_test = preprocessor.transform(X_test)
+
+    return X_train, X_test, y_train, y_test, preprocessor
+
+def train_and_evaluate(X_train, X_test, y_train, y_test, preprocessor):
     model = LogisticRegression()
     model.fit(X_train, y_train)
     y_pred = model.predict(X_test)
@@ -41,14 +62,16 @@ def train_and_evaluate(X_train, X_test, y_train, y_test):
     }
     for name, value in metrics.items():
         print(f"{name.capitalize()}: {value:.4f}")
-    return model
+
+    pipeline = Pipeline(steps=[("preprocessor", preprocessor), ("model", model)])
+    return pipeline
 
 def main():
     df = load_data(DATA_PATH)
-    X_train, X_test, y_train, y_test = prepare_data(df)
-    model = train_and_evaluate(X_train, X_test, y_train, y_test)
-    joblib.dump(model, MODEL_PATH)
-    print(f"Modelo salvo em {MODEL_PATH}")
+    X_train, X_test, y_train, y_test, preprocessor = prepare_data(df)
+    pipeline = train_and_evaluate(X_train, X_test, y_train, y_test, preprocessor)
+    joblib.dump(pipeline, MODEL_PATH)
+    print(f"Pipeline salvo em {MODEL_PATH}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Encode `localizacao`, `ip`, and `cartao` with `OneHotEncoder` during training
- Train and persist a preprocessing + model pipeline
- Load the saved pipeline in the API to apply consistent transformations before inference

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68ad1555d6788323a4bcc2448b2d1a0c