### PR TITLE
feat: configure database url

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -1,11 +1,14 @@
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-DATABASE_URL = "sqlite:///./fraudes.db"
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./fraudes.db")
 
-engine = create_engine(
-    DATABASE_URL, connect_args={"check_same_thread": False}
-)
+engine_kwargs = {}
+if DATABASE_URL.startswith("sqlite"):
+    engine_kwargs["connect_args"] = {"check_same_thread": False}
+
+engine = create_engine(DATABASE_URL, **engine_kwargs)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.8'
 services:
   api:
     build: ./docker/api
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/fraude
     ports:
       - "8000:8000"
     volumes:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 import numpy as np
 import joblib
@@ -13,6 +14,7 @@ model_path = Path("model/model.pkl")
 model_path.parent.mkdir(exist_ok=True)
 joblib.dump(DummyModel(), model_path)
 
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 from api.main import app
 
 
@@ -34,6 +36,9 @@ def test_classify_endpoint():
 
 def teardown_module(module):
     model_path.unlink(missing_ok=True)
-    db_path = Path("fraudes.db")
-    if db_path.exists():
-        db_path.unlink()
+    db_url = os.environ.get("DATABASE_URL", "")
+    if db_url.startswith("sqlite:///"):
+        db_path = Path(db_url.replace("sqlite:///", ""))
+        if db_path.exists():
+            db_path.unlink()
+    os.environ.pop("DATABASE_URL", None)


### PR DESCRIPTION
## Summary
- load database URL from environment with SQLite fallback
- expose PostgreSQL URL via docker compose
- allow tests to configure database URL

## Testing
- `pytest` *(fails: No module named 'httpx')*
- `pytest tests/test_simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad161525a083238f2a4f585119dede