### PR TITLE
Improve CSV handling and add load data test

### DIFF
--- a/model/train.py
+++ b/model/train.py
@@ -1,5 +1,4 @@
 import os
-from io import StringIO
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import LogisticRegression
@@ -14,16 +13,8 @@ DATA_PATH = os.path.join(BASE_DIR, "..", "data", "raw", "transacoes_sinteticas.c
 MODEL_PATH = os.path.join(BASE_DIR, "model.pkl")
 
 def load_data(path: str) -> pd.DataFrame:
-    """Load dataset handling lines split across two rows."""
-    with open(path, encoding="utf-8") as f:
-        lines = f.read().splitlines()
-    header = lines[0]
-    rows = []
-    for i in range(1, len(lines), 2):
-        if i + 1 < len(lines):
-            rows.append(lines[i].strip() + lines[i + 1].strip())
-    csv_data = "\n".join([header] + rows)
-    return pd.read_csv(StringIO(csv_data))
+    """Load dataset from a CSV file."""
+    return pd.read_csv(path, engine="python")
 
 def prepare_data(df: pd.DataFrame):
     df["valor"] = df["valor"].astype(float)

--- a/simulator/generate.py
+++ b/simulator/generate.py
@@ -3,6 +3,7 @@ import random
 import pandas as pd
 import os
 import argparse
+import csv
 from typing import Any, Optional
 
 fake = Faker()
@@ -74,6 +75,6 @@ if __name__ == "__main__":
 
     os.makedirs("data/raw", exist_ok=True)
     caminho_arquivo = "data/raw/transacoes_sinteticas.csv"
-    df.to_csv(caminho_arquivo, index=False)
+    df.to_csv(caminho_arquivo, index=False, quoting=csv.QUOTE_MINIMAL)
 
     print(f"✅ Arquivo gerado com {len(df)} transações em: {caminho_arquivo}")

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -1,0 +1,23 @@
+import csv
+import pandas as pd
+from model.train import load_data
+
+def test_load_data_handles_newline(tmp_path):
+    data = {
+        "id_transacao": ["1"],
+        "nome": ["Nome Teste"],
+        "email": ["a@a.com"],
+        "cartao": ["123456"],
+        "data": ["2025-01-01"],
+        "valor": [100.0],
+        "localizacao": ["Linha\nQuebra"],
+        "ip": ["127.0.0.1"],
+        "fraude": [0],
+    }
+    df = pd.DataFrame(data)
+    file = tmp_path / "dados.csv"
+    df.to_csv(file, index=False, quoting=csv.QUOTE_MINIMAL)
+    loaded = load_data(str(file))
+    assert loaded.loc[0, "localizacao"] == "Linha\nQuebra"
+    assert len(loaded) == 1
+    assert list(loaded.columns) == list(df.columns)


### PR DESCRIPTION
## Summary
- Simplify model data loading using `pd.read_csv` with Python engine
- Ensure simulator writes clean CSVs by using minimal quoting
- Add test verifying `load_data` correctly reads files with newline fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx -q` *(fails: 403 Client Error: Forbidden for url: /simple/httpx/)*
- `pytest tests/test_load_data.py tests/test_simulator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad18969dbc832399f80d08e718e773