### PR TITLE
Remove duplicate dependencies in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,4 @@ sqlalchemy
 requests
 streamlit
 plotly
-scikit-learn
-joblib
 pytest


### PR DESCRIPTION
## Summary
- dedupe repeated scikit-learn and joblib entries in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68ad1a66194483238314de77e518329f