### PR TITLE
Add tests for model training, database operations, and dashboard data loading

### DIFF
--- a/tests/test_dashboard_load_data.py
+++ b/tests/test_dashboard_load_data.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import requests
+
+
+def _setup_secrets(tmp_path):
+    import streamlit.config as config
+    secrets_file = tmp_path / "secrets.toml"
+    secrets_file.write_text("")
+    config.set_option("secrets.files", [str(secrets_file)])
+
+
+def test_load_data_local(tmp_path):
+    _setup_secrets(tmp_path)
+    from dashboard.app import load_data
+    df = pd.DataFrame({'col':[1,2],'fraude':[0,1]})
+    file = tmp_path / 'data.csv'
+    df.to_csv(file, index=False)
+    loaded = load_data(str(file))
+    pd.testing.assert_frame_equal(loaded, df)
+
+
+def test_load_data_remote(tmp_path, monkeypatch):
+    _setup_secrets(tmp_path)
+    from dashboard.app import load_data
+    csv_text = 'col,fraude\n1,0\n2,1\n'
+
+    class MockResponse:
+        def __init__(self, text):
+            self.text = text
+        def raise_for_status(self):
+            pass
+    def mock_get(url, timeout=10):
+        return MockResponse(csv_text)
+    monkeypatch.setattr(requests, 'get', mock_get)
+    loaded = load_data('http://example.com/data.csv')
+    assert list(loaded.columns) == ['col','fraude']
+    assert loaded['col'].tolist() == [1,2]

--- a/tests/test_db_transactions.py
+++ b/tests/test_db_transactions.py
@@ -1,0 +1,33 @@
+import importlib
+import sys
+
+
+def test_insert_and_retrieve_transaction(tmp_path, monkeypatch):
+    db_file = tmp_path / 'test.db'
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{db_file}')
+    sys.modules.pop('db.database', None)
+    sys.modules.pop('db.models', None)
+    database = importlib.import_module('db.database')
+    models = importlib.import_module('db.models')
+    database.init_db()
+    session = database.SessionLocal()
+    trans = models.Transacao(
+        valor=123.45,
+        localizacao='BR',
+        ip='127.0.0.1',
+        cartao='0000',
+        probabilidade_fraude=0.9,
+        is_fraud=True,
+    )
+    session.add(trans)
+    session.commit()
+    session.refresh(trans)
+    fetched = session.query(models.Transacao).filter_by(id=trans.id).first()
+    assert fetched is not None
+    assert fetched.valor == 123.45
+    assert fetched.localizacao == 'BR'
+    assert fetched.ip == '127.0.0.1'
+    assert fetched.cartao == '0000'
+    assert fetched.probabilidade_fraude == 0.9
+    assert fetched.is_fraud is True
+    session.close()

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -1,0 +1,18 @@
+from sklearn.pipeline import Pipeline
+from model.train import load_data, prepare_data, train_and_evaluate, DATA_PATH
+
+def test_train_and_evaluate_metrics(capsys):
+    df = load_data(DATA_PATH)
+    X_train, X_test, y_train, y_test, preprocessor = prepare_data(df)
+    pipeline = train_and_evaluate(X_train, X_test, y_train, y_test, preprocessor)
+    captured = capsys.readouterr()
+    metrics = {}
+    for line in captured.out.strip().splitlines():
+        if ':' in line:
+            name, value = line.split(':')
+            metrics[name.strip().lower()] = float(value.strip())
+    for key in ['accuracy', 'precision', 'recall', 'f1_score']:
+        assert key in metrics
+        assert 0.0 <= metrics[key] <= 1.0
+    assert isinstance(pipeline, Pipeline)
+    assert hasattr(pipeline.named_steps['model'], 'coef_')


### PR DESCRIPTION
## Summary
- add training test for model pipeline with metric assertions
- test SQLite transaction insertion and retrieval
- ensure dashboard `load_data` works with local files and mocked remote requests

## Testing
- `pytest tests/test_train_model.py tests/test_db_transactions.py tests/test_dashboard_load_data.py -q`
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1d4d34a08323853db418837ad5fe